### PR TITLE
install dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,11 @@ FROM node:9.4-stretch
 
 LABEL maintainer=services-engineering@vitals.com
 
-RUN apt-get update && apt-get -y install netcat && apt-get clean
+RUN apt-get update && apt-get -y install netcat wget && apt-get clean
+
+ENV DOCKERIZE_VERSION v0.6.0
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
 RUN npm install --global --quiet ionic cordova@^6


### PR DESCRIPTION
Dockerize is handy for waiting for services when using docker-compose version 3.x, which has lost the `depends_on: service_healthy` feature.

See https://github.com/jwilder/dockerize