### PR TITLE
jessie base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:9.4-stretch
+FROM node:9.4
 
 LABEL maintainer=services-engineering@vitals.com
 


### PR DESCRIPTION
I was a little bit previous basing our node image on debian stretch, so this reverts to the earlier version