### PR TITLE
use latest cordova version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
     && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-RUN npm install --global --quiet ionic cordova@^6
+RUN npm install --global --quiet ionic cordova


### PR DESCRIPTION
I was able to build our mobile app using the latest version of cordova, 8.0. So we can update the base image